### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,5 @@ dev-dependencies = [
     "pytest>=8.3.3",
 ]
 
-[tool.setuptools]
-packages = ["lmeval"]
+[tool.setuptools.packages.find]
+include = ["lmeval*"]


### PR DESCRIPTION
Setting only the package name will not include the submodules (e.g. lmeval.models) in the build. Using custom discovery with include solves this issue.

More info on [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages)